### PR TITLE
MOODLE-4507

### DIFF
--- a/coursenotificationsettings.php
+++ b/coursenotificationsettings.php
@@ -48,6 +48,7 @@ require_login($course);
 $systemcontext = context_system::instance();
 
 $PAGE->set_pagelayout('incourse');
+require_capability('local/augmented_teacher:coursenotificationsettings', $context);
 require_capability('moodle/course:manageactivities', $context);
 
 $PAGE->set_title("$course->shortname: " . get_string('coursenotificationsettings', 'local_augmented_teacher'));

--- a/db/access.php
+++ b/db/access.php
@@ -25,13 +25,60 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$capabilities = array(
-
-    'local/augmented_teacher:receivereminder' => array(
+$capabilities = [
+    'local/augmented_teacher:receivereminder' => [
         'captype' => 'read',
         'contextlevel' => CONTEXT_COURSE,
-        'archetypes' => array(
+        'archetypes' => [
             'student' => CAP_ALLOW
-        )
-    ),
-);
+        ]
+    ],
+    'local/augmented_teacher:mergedmessages' => [
+        'captype' => 'read',
+        'contextlevel' => CONTEXT_COURSE,
+        'archetypes' => [
+            'teacher' => CAP_ALLOW,
+            'editingteacher' => CAP_ALLOW,
+        ]
+    ],
+    'local/augmented_teacher:reminders' => [
+        'captype' => 'read',
+        'contextlevel' => CONTEXT_COURSE,
+        'archetypes' => [
+            'teacher' => CAP_ALLOW,
+            'editingteacher' => CAP_ALLOW,
+        ]
+    ],
+    'local/augmented_teacher:notloggedinreminders' => [
+        'captype' => 'write',
+        'contextlevel' => CONTEXT_COURSE,
+        'archetypes' => [
+            'teacher' => CAP_ALLOW,
+            'editingteacher' => CAP_ALLOW,
+        ]
+    ],
+    'local/augmented_teacher:excludeusersfromreminders' => [
+        'captype' => 'write',
+        'contextlevel' => CONTEXT_COURSE,
+        'archetypes' => [
+            'teacher' => CAP_ALLOW,
+            'editingteacher' => CAP_ALLOW,
+        ]
+    ],
+    'local/augmented_teacher:recommendactivity' => [
+        'captype' => 'write',
+        'contextlevel' => CONTEXT_COURSE,
+        'archetypes' => [
+            'teacher' => CAP_ALLOW,
+            'editingteacher' => CAP_ALLOW,
+        ]
+    ],
+    'local/augmented_teacher:coursenotificationsettings' => [
+        'captype' => 'write',
+        'contextlevel' => CONTEXT_COURSE,
+        'archetypes' => [
+            'teacher' => CAP_ALLOW,
+            'editingteacher' => CAP_ALLOW,
+        ]
+    ],
+];

--- a/excluded_users.php
+++ b/excluded_users.php
@@ -51,6 +51,8 @@ $context = context_course::instance($course->id, MUST_EXIST);
 
 require_login($course);
 
+require_capability('local/augmented_teacher:excludeusersfromreminders', $context);
+
 $PAGE->set_url($thispageurl);
 $PAGE->set_pagelayout('incourse');
 $PAGE->set_context($context);

--- a/lang/en/local_augmented_teacher.php
+++ b/lang/en/local_augmented_teacher.php
@@ -59,7 +59,6 @@ $string['scheduled'] = 'Scheduled';
 $string['submit'] = 'Submit';
 $string['list'] = 'List';
 $string['sendremindermessage'] = 'Send reminder message';
-$string['augmented_teacher:receivereminder'] = 'Receive reminder';
 $string['yes'] = 'Yes';
 $string['no'] = 'No';
 $string['firstname'] = 'First name';
@@ -125,3 +124,12 @@ $string['formattexttype'] = 'Formatting';
 $string['currentlyselectedusers'] = 'Currently selected users';
 $string['allfieldsrequired'] = 'All fields are required';
 $string['previewhtml'] = 'HTML format preview';
+
+// Capabilities
+$string['augmented_teacher:receivereminder'] = 'Receive reminder';
+$string['augmented_teacher:mergedmessages'] = 'Allow user to use "Send merged messages"';
+$string['augmented_teacher:reminders'] = 'Allow user to use "Reminders"';
+$string['augmented_teacher:notloggedinreminders'] = 'Allow user to use "Not logged in reminders"';
+$string['augmented_teacher:excludeusersfromreminders'] = 'Allow user to use "Exclude users from receiving the reminders"';
+$string['augmented_teacher:recommendactivity'] = 'Allow user to use "Recommend activity"';
+$string['augmented_teacher:coursenotificationsettings'] = 'Allow user to use "Course notification settings"';

--- a/lib.php
+++ b/lib.php
@@ -39,7 +39,15 @@ function local_augmented_teacher_extend_settings_navigation($settingsnav, $conte
         return;
     }
 
-    if (has_capability('moodle/course:bulkmessaging', $PAGE->context)) {
+    // Required at least one of these capability to access the plugin functionalities
+    $is_user_capable = has_capability('local/augmented_teacher:mergedmessages', $PAGE->context)
+        || has_capability('local/augmented_teacher:reminders', $PAGE->context)
+        || has_capability('local/augmented_teacher:notloggedinreminders', $PAGE->context)
+        || has_capability('local/augmented_teacher:excludeusersfromreminders', $PAGE->context)
+        || has_capability('local/augmented_teacher:recommendactivity', $PAGE->context)
+        || has_capability('local/augmented_teacher:coursenotificationsettings', $PAGE->context);
+
+    if ($is_user_capable) {
         if ($settingnode = $settingsnav->find('courseadmin', navigation_node::TYPE_COURSE)) {
 
             $keys = $settingnode->get_children_key_list();
@@ -52,7 +60,6 @@ function local_augmented_teacher_extend_settings_navigation($settingsnav, $conte
             $settingnode->add_node($node, $beforekey);
         }
     }
-    return;
 }
 
 /**

--- a/mergedmessages.php
+++ b/mergedmessages.php
@@ -74,6 +74,7 @@ require_login($course);
 $systemcontext = context_system::instance();
 
 $PAGE->set_pagelayout('incourse');
+require_capability('local/augmented_teacher:mergedmessages', $context);
 require_capability('moodle/course:viewparticipants', $context);
 
 $rolenamesurl = new moodle_url("$CFG->wwwroot/local/augmented_teacher/mergedmessages.php?contextid=$context->id&sifirst=&silast=");

--- a/notloggedinreminders.php
+++ b/notloggedinreminders.php
@@ -53,6 +53,7 @@ require_login($course);
 $systemcontext = context_system::instance();
 
 $PAGE->set_pagelayout('incourse');
+require_capability('local/augmented_teacher:notloggedinreminders', $context);
 require_capability('moodle/course:manageactivities', $context);
 
 $PAGE->set_title("$course->shortname: ".get_string('participants'));

--- a/recommendactivity.php
+++ b/recommendactivity.php
@@ -53,6 +53,7 @@ require_login($course);
 $systemcontext = context_system::instance();
 
 $PAGE->set_pagelayout('incourse');
+require_capability('local/augmented_teacher:recommendactivity', $context);
 require_capability('moodle/course:manageactivities', $context);
 
 $PAGE->set_title("$course->shortname: ".get_string('participants'));

--- a/reminders.php
+++ b/reminders.php
@@ -49,6 +49,8 @@ require_login($course);
 $systemcontext = context_system::instance();
 
 $PAGE->set_pagelayout('incourse');
+
+require_capability('local/augmented_teacher:reminders', $context);
 require_capability('moodle/course:manageactivities', $context);
 
 $PAGE->set_title("$course->shortname: ".get_string('participants'));

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version  = 2020061101;
+$plugin->version  = 2020093000;
 $plugin->requires = 2018051700; // Moodle 3.5 required.
 $plugin->component = 'local_augmented_teacher';
-$plugin->release = '1.4.2';
+$plugin->release = '1.4.3';
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
## Fixes
* Remove plugin that rely on "**moodle/course:bulkmessaging**" capability to access plugin functionalities.
## Changes
* Plugin is now rely on it own capabilities to access the functionalities.
* User is now required to have at least one of the new capabilities that make it visible in the course action menu.
* User is now required to have the specific capabilities for the access of the plugin functions.
* Add capabilities for each functionality view.
    - **local/augmented_teacher:mergedmessages**
    - **local/augmented_teacher:reminders**
    - **local/augmented_teacher:notloggedinreminders**
    - **local/augmented_teacher:excludeusersfromreminders**
    - **local/augmented_teacher:recommendactivity**
    - **local/augmented_teacher:coursenotificationsettings**